### PR TITLE
Feature04 history

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -2,7 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 from app.config import DATABASE_URL
 
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(DATABASE_URL, echo=True, connect_args={"statement_cache_size": 0})
 
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -4,9 +4,9 @@ import logging
 from fastapi import FastAPI, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db import async_session
+from app.db import async_session, engine, Base
 from app.dtos.user_dto import UserResponse, UserCreate
-from app.routers import user_router, openai_router
+from app.routers import user_router, openai_router, history_router
 from app.service.user_service import create_user, get_users
 
 app = FastAPI()
@@ -21,6 +21,7 @@ logging = logging.getLogger(__name__)
 # include your routers
 app.include_router(user_router.router)
 app.include_router(openai_router.router)
+app.include_router(history_router.router)
 
 
 async def get_db():

--- a/app/models/message.py
+++ b/app/models/message.py
@@ -16,7 +16,6 @@ class Message(Base):
     content = Column(String, nullable=False)
     translated_content = Column(String, nullable=True)
     created_at = Column(DateTime, default=datetime.now)
-    messages = relationship("Message", back_populates="conversation")
 
     __table_args__ = (
         CheckConstraint("role in ('user', 'assistant')", name="valid_role"),

--- a/app/routers/history_router.py
+++ b/app/routers/history_router.py
@@ -1,0 +1,98 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from typing import List
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from app.db import async_session
+from app.models.conversation import Conversation
+from app.models.message import Message
+import uuid
+from datetime import datetime
+
+router = APIRouter()
+
+
+async def get_session() -> AsyncSession:
+    async with async_session() as session:
+        yield session
+
+
+class MessageCreate(BaseModel):
+    role: str
+    content: str
+    translated_content: str | None = None
+
+
+class HistoryCreate(BaseModel):
+    user_id: uuid.UUID
+    title: str
+    messages: List[MessageCreate]
+
+
+@router.post("/history")
+async def save_history(data: HistoryCreate, session: AsyncSession = Depends(get_session)):
+    try:
+        conversation = Conversation(
+            id=uuid.uuid4(),
+            user_id=data.user_id,
+            title=data.title,
+            created_at=datetime.now()
+        )
+        session.add(conversation)
+
+        # reflect conversation.id in DB
+        await session.flush()
+
+        for m in data.messages:
+            message = Message(
+                id=uuid.uuid4(),
+                conversation_id=conversation.id,
+                role=m.role,
+                content=m.content,
+                translated_content=m.translated_content,
+                created_at=datetime.now()
+            )
+            session.add(message)
+
+        await session.commit()
+        return {"conversation_id": str(conversation.id)}
+
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/history/{user_id}")
+async def get_user_history(user_id: uuid.UUID, session: AsyncSession = Depends(get_session)):
+    try:
+        result = await session.execute(
+            select(Conversation).where(Conversation.user_id == user_id).order_by(Conversation.created_at.desc())
+        )
+        conversations = result.scalars().all()
+
+        history = []
+        for conv in conversations:
+            conv_result = await session.execute(
+                select(Message).where(Message.conversation_id == conv.id).order_by(Message.created_at)
+            )
+            messages = conv_result.scalars().all()
+
+            history.append({
+                "conversation_id": str(conv.id),
+                "title": conv.title,
+                "created_at": conv.created_at,
+                "messages": [
+                    {
+                        "role": msg.role,
+                        "content": msg.content,
+                        "translated_content": msg.translated_content,
+                        "created_at": msg.created_at
+                    } for msg in messages
+                ]
+            })
+
+        return history
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+

--- a/app/routers/openai_router.py
+++ b/app/routers/openai_router.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, UploadFile, File, Form
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 import openai
 import os
@@ -51,3 +52,19 @@ async def translate_text(data: TranslateRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/transcribe")
+async def transcribe_audio(audio_file: UploadFile = File(...), language: str = Form(None)):
+    try:
+        contents = await audio_file.read()
+        response = openai.audio.transcriptions.create(
+            model="whisper-1",
+            file=(audio_file.filename, contents),
+            language=language
+        )
+        return {"transcription": response.text}
+
+    except Exception as e:
+        raise JSONResponse(status_code=500, contents={"error": str(e)})
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ asyncpg==0.29.0
 gTTS==2.3.2
 openai==1.17.0
 python-dotenv==1.0.1
+python-multipart==0.0.20
 psycopg2==2.9.10
 httpx==0.27.0
 


### PR DESCRIPTION
- add `/transcribe` method 
- set statement cache size = 0
```Python
engine = create_async_engine(DATABASE_URL, echo=True)
```
When engine is like that, it causes error at POST `/history` method
<img width="626" alt="prepare_statement_error" src="https://github.com/user-attachments/assets/7b45d29c-3d1b-4553-b6d3-b2a6ff7db41b" />

This is a known issue when using `pgbouncer` in either `"transaction"` or `"statement"` pool mode with `asyncpg`, because `asyncpg` relies on prepared statements, which `pgbouncer` can't manage correctly in those modes.

Set `statement_cache_size=0` when creating the `asyncpg` connection. This tells `asyncpg` not to prepare statements, avoiding the error.

- add save conversation 

<img width="598" alt="Save_conversation_result" src="https://github.com/user-attachments/assets/fccf7c71-80d5-40f2-aef4-0a7360b89b4d" />

saved data
**conversation**
<img width="708" alt="conversation_record" src="https://github.com/user-attachments/assets/d9dc3ac2-7f71-4d60-b202-ea2ccb516ccf" />

**message**
<img width="731" alt="messages_records" src="https://github.com/user-attachments/assets/9d9b0a39-5a6b-4311-9415-a24c0079d87b" />


- get conversation by user_id 

<img width="537" alt="get_conversation_result" src="https://github.com/user-attachments/assets/cb17b072-9a85-40f0-bba2-8110db8d33b4" />


