### PR TITLE
history openai api enhance

### DIFF
--- a/app/dtos/openai_dto.py
+++ b/app/dtos/openai_dto.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class ChatRequest(BaseModel):
+    message: str
+    history: list
+    language: str = "ja"
+
+
+class TranslateRequest(BaseModel):
+    text: str
+    target_language: str
+

--- a/app/routers/history_router.py
+++ b/app/routers/history_router.py
@@ -5,30 +5,37 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from app.db import async_session
+from app.dtos.openai_dto import ChatRequest
 from app.dtos.response_dto import api_response
 from app.models import User
 from app.models.conversation import Conversation
 from app.models.message import Message
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from app.db import get_db
 from app.service.auth_service import get_current_user
-from app.service.openai_service import generate_title
+from app.service.gtts_service import create_audio_and_upload
+from app.service.openai_service import generate_title, chat_with_gpt, translate_text
 
 router = APIRouter()
 
 
-class MessageCreate(BaseModel):
+class MessageBase(BaseModel):
     role: str
     content: str
-    translated_content: str | None = None
-    audio_url: str | None
+    translatedContent: str | None = None
+    audioUrl: str | None
 
 
 class HistoryCreate(BaseModel):
-    user_id: uuid.UUID
+    userId: uuid.UUID
     title: str | None
-    messages: List[MessageCreate]
+    messages: List[MessageBase]
+
+
+class MessagesCreate(BaseModel):
+    conversationId: str
+    messages: List[MessageBase]
 
 
 @router.post("/history")
@@ -45,7 +52,7 @@ async def save_history(
 
         conversation = Conversation(
             id=uuid.uuid4(),
-            user_id=data.user_id,
+            user_id=data.userId,
             title=data.title,
             created_at=datetime.now()
         )
@@ -60,8 +67,8 @@ async def save_history(
                 conversation_id=conversation.id,
                 role=m.role,
                 content=m.content,
-                translated_content=m.translated_content,
-                audio_url=m.audio_url,
+                translated_content=m.translatedContent,
+                audio_url=m.audioUrl,
                 created_at=datetime.now()
             )
             session.add(message)
@@ -93,16 +100,16 @@ async def get_user_history(
             messages = conv_result.scalars().all()
 
             history.append({
-                "conversation_id": str(conv.id),
+                "conversationId": str(conv.id),
                 "title": conv.title,
-                "created_at": conv.created_at,
+                "createdAt": conv.created_at,
                 "messages": [
                     {
                         "role": msg.role,
                         "content": msg.content,
-                        "translated_content": msg.translated_content,
-                        "audio_url": msg.audio_url,
-                        "created_at": msg.created_at
+                        "translatedContent": msg.translated_content,
+                        "audioUrl": msg.audio_url,
+                        "createdAt": msg.created_at
                     } for msg in messages
                 ]
             })
@@ -164,3 +171,80 @@ async def get_conversation_messages(
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
+@router.post("/save-messages")
+async def save_messages(
+        data: MessagesCreate,
+        session: AsyncSession = Depends(get_db),
+        current_user: User = Depends(get_current_user)):
+    try:
+        result = await session.execute(
+            select(Conversation).where(Conversation.id == data.conversationId)
+        )
+        conversation = result.scalars().all()
+        if not conversation:
+            return api_response(400, "Invalid conversationId")
+
+        for m in data.messages:
+            message = Message(
+                id=uuid.uuid4(),
+                conversation_id=data.conversationId,
+                role=m.role,
+                content=m.content,
+                translated_content=m.translatedContent,
+                audio_url=m.audioUrl,
+                created_at=datetime.now()
+            )
+            session.add(message)
+
+        await session.commit()
+        return api_response(200, "success")
+
+    except Exception as e:
+        await session.rollback()
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+import time
+import logging
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+@router.post("/text-chat")
+async def chat(
+        payload: ChatRequest,
+        current_user: User = Depends(get_current_user)):
+    start_time = time.time()
+    logger.info("💬 Chat API called")
+
+    try:
+        # Call OpenAI
+        openai_start = time.time()
+        reply = await chat_with_gpt(payload)
+        logger.info(f"🧠 OpenAI response time: {time.time() - openai_start:.2f} sec")
+
+        # Translate
+        translate_start = time.time()
+        translated_text = await translate_text(reply, payload.language)
+        logger.info(f"🌍 Translation time: {time.time() - translate_start:.2f} sec")
+
+        # TTS
+        tts_start = time.time()
+        audio_url = await create_audio_and_upload(reply, payload.language)
+        logger.info(f"🔊 TTS time: {time.time() - tts_start:.2f} sec")
+
+        logger.info(f"✅ Total chat endpoint time: {time.time() - start_time:.2f} sec")
+
+        response_data = {
+            "role": "assistant",
+            "content": reply,
+            "translatedContent": translated_text,
+            "audioUrl": audio_url
+        }
+
+        return api_response(200, "success", response_data)
+    except Exception as e:
+        logger.exception("❌ Chat API failed")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/routers/openai_router.py
+++ b/app/routers/openai_router.py
@@ -1,13 +1,14 @@
 from dotenv import load_dotenv
 from fastapi import APIRouter, HTTPException, UploadFile, File, Form, Depends
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
 import openai
 import os
 
+from app.dtos.openai_dto import ChatRequest, TranslateRequest
 from app.dtos.response_dto import api_response
 from app.models import User
 from app.service.auth_service import get_current_user
+from app.service.openai_service import chat_with_gpt, translate_text
 
 load_dotenv()
 
@@ -16,43 +17,19 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 router = APIRouter()
 
 
-class ChatRequest(BaseModel):
-    message: str
-    history: list
-    language: str = "ja"
-
-
-class TranslateRequest(BaseModel):
-    text: str
-    target_language: str
-
-
 @router.post("/chat")
-async def chat_with_gpt(data: ChatRequest, current_user: User = Depends(get_current_user)):
+async def chat(data: ChatRequest, current_user: User = Depends(get_current_user)):
     try:
-        messages = [{"role": m["role"], "content": m["content"]} for m in data.history]
-        messages.append({"role": "user", "content": data.message})
-
-        response = openai.chat.completions.create(
-            model="gpt-4-0613",
-            messages=messages
-        )
-        reply = response.choices[0].message.content
+        reply = await chat_with_gpt(data)
         return api_response(200, "success", reply)
-
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/translate")
-async def translate_text(data: TranslateRequest, current_user: User = Depends(get_current_user)):
+async def translate(data: TranslateRequest, current_user: User = Depends(get_current_user)):
     try:
-        prompt = f"translate below sentences to {data.target_language}. \n\n{data.text}"
-        response = openai.chat.completions.create(
-            model="gpt-4-0613",
-            messages=[{"role": "user", "content": prompt}]
-        )
-        translated_text = response.choices[0].message.content
+        translated_text = await translate_text(data.text, data.target_language)
         return api_response(200, "success", translated_text)
 
     except Exception as e:
@@ -66,7 +43,7 @@ async def transcribe_audio(
         current_user: User = Depends(get_current_user)):
     try:
         contents = await audio_file.read()
-        response = openai.audio.transcriptions.create(
+        response = await openai.audio.transcriptions.create(
             model="whisper-1",
             file=(audio_file.filename, contents),
             language=language

--- a/app/routers/tts_router.py
+++ b/app/routers/tts_router.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from fastapi.responses import StreamingResponse
 from gtts import gTTS
 
+from app.dtos.response_dto import api_response
 from app.service.gtts_service import create_audio_and_upload
 
 router = APIRouter()
@@ -30,6 +31,9 @@ async def text_to_speech(data: TTSRequest):
 
 @router.post("/tts-api")
 async def tts_api(data: TTSRequest):
-    url = create_audio_and_upload(data.text, data.language)
-    return {"audio_url": url}
+    try:
+        url = await create_audio_and_upload(data.text, data.language)
+        return api_response(200, "success", {"audio_url": url})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 

--- a/app/service/gtts_service.py
+++ b/app/service/gtts_service.py
@@ -1,24 +1,35 @@
 import os.path
-
+import asyncio
 from dotenv import load_dotenv
 from gtts import gTTS
 from supabase import create_client
 import uuid
+import time
+import logging
 
 load_dotenv()
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SERVICE_ROLE_SECRET")
 supabase_client = create_client(SUPABASE_URL, SUPABASE_KEY)
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
-def generate_audio(text: str, lang: str = "ja") -> str:
+
+def _generate_audio(text: str, lang: str = "ja") -> str:
     tts = gTTS(text=text, lang=lang)
     filename = f"{uuid.uuid4()}.mp3"
     tts.save(filename)
     return filename
 
 
-def upload_to_supabase(filepath: str, bucket: str) -> str:
+async def generate_audio_async(text: str, lang: str = "ja") -> str:
+    """同期的な generate_audio を別スレッドで実行する非同期ラッパー"""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _generate_audio, text, lang)
+
+
+def _upload_to_supabase(filepath: str, bucket: str) -> str:
     """
     :rtype: str
     """
@@ -33,10 +44,20 @@ def upload_to_supabase(filepath: str, bucket: str) -> str:
     return public_url
 
 
-def create_audio_and_upload(text: str, lang: str = "ja", bucket: str = "ai-speak") -> str:
-    mp3_file = generate_audio(text, lang)
+async def upload_to_supabase_async(filepath: str, bucket: str) -> str:
+    """同期的な upload_to_supabase を別スレッドで実行する非同期ラッパー"""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _upload_to_supabase, filepath, bucket)
+
+
+async def create_audio_and_upload(text: str, lang: str = "ja", bucket: str = "ai-speak") -> str:
+    start = time.time()
+    mp3_file = await generate_audio_async(text, lang)
+    logger.info(f"TTS生成: {time.time() - start:.2f} sec")
     try:
-        url = upload_to_supabase(mp3_file, bucket)
+        start_upload = time.time()
+        url = await upload_to_supabase_async(mp3_file, bucket)
+        logger.info(f"Supabaseアップロード: {time.time() - start_upload:.2f} sec")
         return url
     finally:
         os.remove(mp3_file)

--- a/app/service/history_service.py
+++ b/app/service/history_service.py
@@ -1,0 +1,22 @@
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_db
+from app.models import Message, Conversation
+
+
+class HistoryService:
+    async def get_message(self, conversation_id: str, session: AsyncSession = Depends(get_db)):
+        result = await session.execute(
+            select(Message).where(Message.conversation_id == conversation_id).order_by(Message.created_at.asc())
+        )
+        messages = result.scalars().all()
+        return messages
+
+    async def get_conversation(self, conversation_id: str, session: AsyncSession = Depends(get_db)):
+        result = await session.execute(
+            select(Conversation).where(Conversation.id == conversation_id)
+        )
+        conversation = result.scalars().first()
+        return conversation

--- a/app/service/openai_service.py
+++ b/app/service/openai_service.py
@@ -1,6 +1,9 @@
 from dotenv import load_dotenv
+from fastapi import HTTPException
 from openai import AsyncClient
 import os
+
+from app.dtos.openai_dto import ChatRequest
 
 load_dotenv()
 client = AsyncClient(api_key=os.getenv("OPENAI_API_KEY"))
@@ -22,4 +25,34 @@ async def generate_title(message: list[str], language: str = "ja") -> str:
     )
 
     return response.choices[0].message.content.strip()
+
+
+async def chat_with_gpt(data: ChatRequest) -> str:
+    try:
+        messages = [{"role": m["role"], "content": m["content"]} for m in data.history]
+        messages.append({"role": "user", "content": data.message})
+
+        response = await client.chat.completions.create(
+            model="gpt-4-0613",
+            messages=messages
+        )
+        reply = response.choices[0].message.content
+        return reply
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def translate_text(text: str, target_language: str) -> str:
+    try:
+        prompt = f"translate below sentences to {target_language}. \n\n{text}"
+        response = await client.chat.completions.create(
+            model="gpt-3.5-turbo-1106",
+            messages=[{"role": "user", "content": prompt}]
+        )
+        translated_text = response.choices[0].message.content
+        return translated_text
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
- add `/save-messages` api
- refactor `/chat`, `/translate` API to use `openai_service` 
- Change model to use `gpt-3.5-turbo-1106` instead of `gpt-4-0613` to improve translate speed
- add `/text-chat` api

<img width="739" alt="add_text_chat_api" src="https://github.com/user-attachments/assets/f21f8e41-d193-4633-85ea-7042e39c690b" />

log for `text-chat` 
```
INFO:app.routers.history_router:💬 Chat API called
INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
INFO:app.routers.history_router:🧠 OpenAI response time: 9.33 sec
INFO:httpx:HTTP Request: POST https://api.openai.com/v1/chat/completions "HTTP/1.1 200 OK"
INFO:app.routers.history_router:🌍 Translation time: 1.48 sec
INFO:app.service.gtts_service:TTS generate: 12.49 sec
INFO:httpx:HTTP Request: POST https://xxxxxxxxxxxx/06143b5f-2ed7-471c-9eec-551b746eaae2.mp3 "HTTP/2 200 OK"
INFO:app.service.gtts_service:Supabase UPLOAD: 1.06 sec
INFO:app.routers.history_router:🔊 TTS time: 13.55 sec
INFO:app.routers.history_router:✅ Total chat endpoint time: 24.36 sec
2025-04-24 15:28:17,378 INFO sqlalchemy.engine.Engine ROLLBACK
INFO:sqlalchemy.engine.Engine:ROLLBACK
INFO:     127.0.0.1:60931 - "POST /text-chat HTTP/1.1" 200 OK
```
so far bottle neck is TTS generate.
In next PR, try to use `tts-1` openai model instead `gTTS` 